### PR TITLE
Add overview of the GitOps repository organization

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -8,7 +8,7 @@ Within a GitOps setup, there can be many [Environments](#Environment), [Applicat
 ![Manifest Model](img/pipelines_model.png)
  
 
-Pipelines Model is defined in a yaml file.   Here is an example a pipelines.yaml
+Pipelines Model is defined in a yaml file.  Here is an example pipelines.yaml
 
 ```yaml
 environments:
@@ -46,23 +46,23 @@ There are three types of Environments
 
 ### CI/CD Environment
 
-The CI/CD Environment is a special Evironment that contains CI/CD pipelines.   These pipelines respond to changes in GitOps configuraiton repository and Application/Service soruce repositories.   They are responisble for keeping the resources in the cluster in-sync with the configurations in Git and re-build/re-deploy application/servcie images.
+The CI/CD Environment is a special Environment that contains CI/CD pipelines.  These pipelines respond to changes in GitOps configuraiton repository and Application/Service soruce repositories.  They are responisble for keeping the resources in the cluster in-sync with the configurations in Git and re-build/re-deploy application/service images.
 
 ### ArgoCD Environment
 
-ArgoCD is used to perform Continuous Delivery of Applications.   When an Application is created in the target Environment.  An ArgoCD application is also created and kept in the ArgoCD Environment.  The user is reponsible for creating deployment.yaml in the "config" folder for the application.  ArgoCD will deploy the application based on the user-provided deployment specification and re-deploy it automatically when the specification is changed.
+ArgoCD is used to perform Continuous Delivery of Applications.  When an Application is created in the target Environment an ArgoCD application is also created and kept in the ArgoCD Environment.  The user is reponsible for creating deployment.yaml in the "config" folder for the application.  ArgoCD will deploy the application based on the user-provided deployment specification and re-deploy it automatically when the specification is changed.
 
 ### (Plain Old) Enviroment
 
-Within a Pipelines Model, there are many Enviroments which hold Applications and Servcies.  Each Environment has its own namespace.
+Within a Pipelines Model, there are many Environments which hold Applications and Services.  Each Environment has its own namespace.
 
 ## Application
 
-An Application is a logical grouping of Services.  It contains references to Services.   When an Application is deployed, all referenced Services are deployed.   Two Applications can reference to a same Service.  Each Application can have specific  customerization to the Service it references/deploys.  A Service cannot be deployed by itself (without an Application).
+An Application is a logical grouping of Services.  It contains references to Services.  When an Application is deployed, all referenced Services are deployed.  Two Applications can reference to a same Service.  Each Application can have specific customization to the Service it references/deploys.  A Service cannot be deployed by itself (without an Application).
 
 ## Service
 
-A Service can have a source repository and an image repository.  Services are unique within an Anvironment.  However, no two Services can share a same source Git reposiotry even though they belong to different Environments.
+A Service can have a source repository and an image repository.  Services are unique within an Environment.  However, no two Services can share a same source Git reposiotry even though they belong to different Environments.
 
 ## GitOps Repository
 

--- a/model/README.md
+++ b/model/README.md
@@ -63,3 +63,33 @@ An Application is a logical grouping of Services.  It contains references to Ser
 ## Service
 
 A Service can have a source repository and an image repository.  Services are unique within an Anvironment.  However, no two Services can share a same source Git reposiotry even though they belong to different Environments.
+
+## GitOps Repository
+
+A GitOps repository is just a Git repository organized to be used with GitOps tools. It organizes the Environments, Applications, and Services with any customization necessary for deployment.
+
+Different Environments are stored in different directories under the `environments/` directory in the GitOps repository. Configuration in is then separated into layers reflected by these sub-directories:
+
+- `env/` - Configuration specific to the namespace / Environment.
+- `apps/*` - Configuration folders specific to each Application.
+- `services/*` - Configuration folders specific to each Service.
+
+Each configuration directory will contain Kustomization files structured like this:
+```
+.
+├── base
+│   ├── *.yaml
+│   └── kustomization.yaml
+└── overlays
+    ├── *.yaml
+    └── kustomization.yaml
+```
+
+Each Service is defined in its `.../services/<service-name>/base/` directory in various YAML files, and its `overlays/` directory includes more specific details such as pod scaling and environment variables. The configuration of each service can be maintained by just a development team, and should be individually deployable with a `kubectl apply -k ` command, which allows for quick testing.
+
+Each Application’s `.../apps/<app-name>/base/kustomization.yaml` will refer to each Service which it uses. Again, the `overlays/` directory will include new specific configuration files required for the application, for example new labels or other details to connect the services. 
+
+Finally, the `.../env/base/kustomization.yaml` will refer to each application which is to be deployed in the environment, and the `env/overlays/` directory will contain any specifics required for the environment. For example, details about service accounts and specific Ingress URLs could be specified here. It will also have a `.../env/kustomization.yaml` file so that the fully-configured applications can be deployed into the environment with this command:
+```
+kubectl apply -k environments/<env-name>/env/
+```


### PR DESCRIPTION
The `model/` section gives useful information about Environments, Applications, and Services, but there is not a section describing how this information is stored inside the actual GitOps repository.

I felt it made sense to add the section into the `model/` README, but it could go somewhere else.